### PR TITLE
Refine public API surface and add comprehensive documentation

### DIFF
--- a/.cursor/rules/plan-then-act-mode.mdc
+++ b/.cursor/rules/plan-then-act-mode.mdc
@@ -1,0 +1,16 @@
+---
+alwaysApply: true
+---
+## Core Rules
+
+You have two modes of operation:
+
+1. Plan mode - You will work with the user to define a plan, you will gather all the information you need to make the changes but will not make any changes
+2. Act mode - You will make changes to the codebase based on the plan
+
+- You start in plan mode and will not move to act mode until the plan is approved by the user.
+- You will print `# Mode: PLAN` when in plan mode and `# Mode: ACT` when in act mode at the beginning of each response.
+- Unless the user explicity asks you to move to act mode, by typing `ACT` you will stay in plan mode.
+- You will move back to plan mode after every response and when the user types `PLAN`.
+- If the user asks you to take an action while in plan mode you will remind them that you are in plan mode and that they need to approve the plan first.
+- When in plan mode always output the full updated plan in every response.

--- a/src/Channels/Agentix.Channels.Slack/Models/SlackModels.cs
+++ b/src/Channels/Agentix.Channels.Slack/Models/SlackModels.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Serialization;
 namespace Agentix.Channels.Slack.Models;
 
 /// <summary>
-/// Slack event callback structure
+/// Internal model representing a Slack event callback structure.
 /// </summary>
-public class SlackEventCallback
+internal class SlackEventCallback
 {
     [JsonPropertyName("token")]
     public string Token { get; set; } = string.Empty;
@@ -34,9 +34,9 @@ public class SlackEventCallback
 }
 
 /// <summary>
-/// Slack event data
+/// Internal model representing Slack event data.
 /// </summary>
-public class SlackEvent
+internal class SlackEvent
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
@@ -67,9 +67,9 @@ public class SlackEvent
 }
 
 /// <summary>
-/// Slack message post request
+/// Internal model representing a Slack message post request.
 /// </summary>
-public class SlackMessageRequest
+internal class SlackMessageRequest
 {
     [JsonPropertyName("channel")]
     public string Channel { get; set; } = string.Empty;
@@ -91,9 +91,9 @@ public class SlackMessageRequest
 }
 
 /// <summary>
-/// Slack API response
+/// Internal model representing a Slack API response.
 /// </summary>
-public class SlackApiResponse
+internal class SlackApiResponse
 {
     [JsonPropertyName("ok")]
     public bool Ok { get; set; }
@@ -109,18 +109,18 @@ public class SlackApiResponse
 }
 
 /// <summary>
-/// Slack user info response
+/// Internal model representing a Slack user info response.
 /// </summary>
-public class SlackUserInfoResponse : SlackApiResponse
+internal class SlackUserInfoResponse : SlackApiResponse
 {
     [JsonPropertyName("user")]
     public SlackUser? User { get; set; }
 }
 
 /// <summary>
-/// Slack user data
+/// Internal model representing Slack user data.
 /// </summary>
-public class SlackUser
+internal class SlackUser
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
@@ -139,18 +139,18 @@ public class SlackUser
 }
 
 /// <summary>
-/// Slack channel info response
+/// Internal model representing a Slack channel info response.
 /// </summary>
-public class SlackChannelInfoResponse : SlackApiResponse
+internal class SlackChannelInfoResponse : SlackApiResponse
 {
     [JsonPropertyName("channel")]
     public new SlackChannel? Channel { get; set; }
 }
 
 /// <summary>
-/// Slack channel data
+/// Internal model representing Slack channel data.
 /// </summary>
-public class SlackChannel
+internal class SlackChannel
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
@@ -168,21 +168,19 @@ public class SlackChannel
     public bool IsIm { get; set; }
 }
 
-// Socket Mode specific models
-
 /// <summary>
-/// Socket Mode connection response from apps.connections.open
+/// Internal model representing Socket Mode connection response from apps.connections.open.
 /// </summary>
-public class SocketModeConnectionResponse : SlackApiResponse
+internal class SocketModeConnectionResponse : SlackApiResponse
 {
     [JsonPropertyName("url")]
     public string? Url { get; set; }
 }
 
 /// <summary>
-/// Socket Mode envelope for all WebSocket messages
+/// Internal model representing Socket Mode envelope for all WebSocket messages.
 /// </summary>
-public class SocketModeEnvelope
+internal class SocketModeEnvelope
 {
     [JsonPropertyName("envelope_id")]
     public string EnvelopeId { get; set; } = string.Empty;
@@ -204,9 +202,9 @@ public class SocketModeEnvelope
 }
 
 /// <summary>
-/// Socket Mode acknowledgment message
+/// Internal model representing Socket Mode acknowledgment message.
 /// </summary>
-public class SocketModeAck
+internal class SocketModeAck
 {
     [JsonPropertyName("envelope_id")]
     public string EnvelopeId { get; set; } = string.Empty;
@@ -216,9 +214,9 @@ public class SocketModeAck
 }
 
 /// <summary>
-/// Socket Mode ping message
+/// Internal model representing Socket Mode ping message.
 /// </summary>
-public class SocketModePing
+internal class SocketModePing
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = "ping";
@@ -228,9 +226,9 @@ public class SocketModePing
 }
 
 /// <summary>
-/// Socket Mode pong response
+/// Internal model representing Socket Mode pong response.
 /// </summary>
-public class SocketModePong
+internal class SocketModePong
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = "pong";

--- a/src/Channels/Agentix.Channels.Slack/SlackChannelOptions.cs
+++ b/src/Channels/Agentix.Channels.Slack/SlackChannelOptions.cs
@@ -1,129 +1,266 @@
 namespace Agentix.Channels.Slack;
 
+/// <summary>
+/// Specifies the connection method for communicating with Slack.
+/// </summary>
 public enum SlackChannelMode
 {
     /// <summary>
-    /// Use HTTP webhooks (requires public HTTPS endpoint)
+    /// Use HTTP webhooks for receiving events from Slack.
+    /// Requires a publicly accessible HTTPS endpoint but offers better scalability.
     /// </summary>
+    /// <remarks>
+    /// Webhook mode is ideal for production environments with proper infrastructure.
+    /// Slack sends HTTP POST requests to your configured endpoint when events occur.
+    /// </remarks>
     Webhook,
     
     /// <summary>
-    /// Use WebSocket connections (works behind firewalls, great for development)
+    /// Use WebSocket connections via Slack's Socket Mode for real-time communication.
+    /// Works behind firewalls and NAT, making it perfect for development environments.
     /// </summary>
+    /// <remarks>
+    /// Socket Mode maintains a persistent WebSocket connection to Slack's servers.
+    /// This mode is excellent for development and environments without public endpoints.
+    /// </remarks>
     SocketMode
 }
 
-public class SlackChannelOptions
+/// <summary>
+/// Configuration options for the Slack channel adapter.
+/// Contains settings for connection methods, bot behavior, security, and user interaction preferences.
+/// </summary>
+public sealed class SlackChannelOptions
 {
     /// <summary>
-    /// The connection mode to use (Webhook or SocketMode)
+    /// Gets or sets the connection mode to use for communicating with Slack.
     /// </summary>
+    /// <value>The connection mode. Defaults to <see cref="SlackChannelMode.Webhook"/>.</value>
+    /// <remarks>
+    /// Choose <see cref="SlackChannelMode.Webhook"/> for production environments with public endpoints,
+    /// or <see cref="SlackChannelMode.SocketMode"/> for development or environments behind firewalls.
+    /// </remarks>
     public SlackChannelMode Mode { get; set; } = SlackChannelMode.Webhook;
 
     /// <summary>
-    /// The Slack bot token (xoxb-...) for authenticating with Slack API
+    /// Gets or sets the Slack bot token for authenticating with the Slack API.
     /// </summary>
+    /// <value>The bot token starting with "xoxb-". This field is required.</value>
+    /// <remarks>
+    /// Obtain this token from your Slack app's "OAuth and Permissions" page after installing
+    /// the app to your workspace. The token should have appropriate bot token scopes
+    /// such as chat:write, channels:history, and users:read.
+    /// </remarks>
     public string BotToken { get; set; } = string.Empty;
 
     /// <summary>
-    /// The signing secret for verifying Slack webhook requests (required for Webhook mode)
+    /// Gets or sets the signing secret for verifying Slack webhook requests.
     /// </summary>
+    /// <value>The signing secret string. Required for webhook mode.</value>
+    /// <remarks>
+    /// This secret is used to verify that webhook requests actually come from Slack
+    /// and haven't been tampered with. Find this in your Slack app's "Basic Information" page.
+    /// Required when <see cref="Mode"/> is <see cref="SlackChannelMode.Webhook"/>.
+    /// </remarks>
     public string SigningSecret { get; set; } = string.Empty;
 
     /// <summary>
-    /// The app-level token (xapp-...) for Socket Mode authentication (required for SocketMode)
+    /// Gets or sets the app-level token for Socket Mode authentication.
     /// </summary>
+    /// <value>The app-level token starting with "xapp-". Required for Socket Mode.</value>
+    /// <remarks>
+    /// Create this token in your Slack app's "Socket Mode" page with the connections:write scope.
+    /// This token allows your application to establish a WebSocket connection to Slack.
+    /// Required when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// </remarks>
     public string AppToken { get; set; } = string.Empty;
 
     /// <summary>
-    /// The port to listen on for incoming Slack webhooks (defaults to 3000)
+    /// Gets or sets the port to listen on for incoming Slack webhooks.
     /// </summary>
+    /// <value>The port number. Defaults to 3000.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.Webhook"/>.
+    /// Ensure this port is accessible from the internet and configure your Slack app's
+    /// Event Subscriptions URL accordingly.
+    /// </remarks>
     public int WebhookPort { get; set; } = 3000;
 
     /// <summary>
-    /// The path for the Slack events webhook endpoint (defaults to /slack/events)
+    /// Gets or sets the URL path for the Slack events webhook endpoint.
     /// </summary>
+    /// <value>The webhook path. Defaults to "/slack/events".</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.Webhook"/>.
+    /// This should match the path configured in your Slack app's Event Subscriptions URL.
+    /// For example: https://yourdomain.com:3000/slack/events
+    /// </remarks>
     public string WebhookPath { get; set; } = "/slack/events";
 
     /// <summary>
-    /// Whether to respond to mentions only or all messages in channels the bot has access to
+    /// Gets or sets a value indicating whether the bot should only respond when mentioned in channels.
     /// </summary>
+    /// <value>True to respond only to mentions; false to respond to all messages. Defaults to true.</value>
+    /// <remarks>
+    /// When true, the bot will only respond to messages that explicitly mention it (e.g., @botname).
+    /// When false, the bot will respond to all messages in channels it has access to.
+    /// Direct messages are controlled separately by <see cref="RespondToDirectMessages"/>.
+    /// </remarks>
     public bool RespondToMentionsOnly { get; set; } = true;
 
     /// <summary>
-    /// Whether to respond to direct messages
+    /// Gets or sets a value indicating whether the bot should respond to direct messages.
     /// </summary>
+    /// <value>True to respond to direct messages; otherwise, false. Defaults to true.</value>
+    /// <remarks>
+    /// Direct messages are private conversations between a user and the bot.
+    /// This setting is independent of <see cref="RespondToMentionsOnly"/>.
+    /// </remarks>
     public bool RespondToDirectMessages { get; set; } = true;
 
     /// <summary>
-    /// Maximum length for responses (Slack has a 4000 character limit for messages)
+    /// Gets or sets the maximum length for bot responses.
     /// </summary>
+    /// <value>The maximum response length in characters. Defaults to 3900.</value>
+    /// <remarks>
+    /// Slack has a 4000 character limit for messages. Setting this slightly lower (3900)
+    /// provides buffer space for metadata and formatting. Longer responses will be truncated
+    /// with a note indicating the truncation.
+    /// </remarks>
     public int MaxResponseLength { get; set; } = 3900;
 
     /// <summary>
-    /// Whether to use threading for responses in channels
+    /// Gets or sets a value indicating whether to use threading for bot responses in channels.
     /// </summary>
+    /// <value>True to use threads; otherwise, false. Defaults to true.</value>
+    /// <remarks>
+    /// When enabled, bot responses will be posted as replies in threads, keeping
+    /// conversations organized. Disable this if you prefer responses to appear
+    /// as new messages in the channel.
+    /// </remarks>
     public bool UseThreading { get; set; } = true;
 
     /// <summary>
-    /// Whether to include usage metadata in responses (for debugging/monitoring)
+    /// Gets or sets a value indicating whether to include usage metadata in bot responses.
     /// </summary>
+    /// <value>True to show metadata such as token usage and costs; otherwise, false. Defaults to false.</value>
+    /// <remarks>
+    /// When enabled, responses will include information like token counts and estimated costs.
+    /// This is useful for debugging and monitoring but may not be desired in production.
+    /// Example: "📊 Tokens: 45 in, 128 out ($0.0023)"
+    /// </remarks>
     public bool ShowMetadata { get; set; } = false;
 
     /// <summary>
-    /// Custom bot name to display in Slack (if different from configured bot user)
+    /// Gets or sets a custom bot name to display in Slack.
     /// </summary>
+    /// <value>The custom bot name, or null to use the configured bot user name.</value>
+    /// <remarks>
+    /// This overrides the bot's configured username for display purposes.
+    /// Useful for providing context-specific names or branding.
+    /// </remarks>
     public string? BotName { get; set; }
 
     /// <summary>
-    /// Custom emoji to use as bot icon
+    /// Gets or sets a custom emoji to use as the bot's icon.
     /// </summary>
+    /// <value>The emoji name (e.g., ":robot_face:"), or null to use the bot's configured icon.</value>
+    /// <remarks>
+    /// Use standard Slack emoji names including the colons.
+    /// Examples: ":robot_face:", ":speech_balloon:", ":artificial_intelligence:"
+    /// </remarks>
     public string? BotEmoji { get; set; }
 
     /// <summary>
-    /// List of channel IDs where the bot should operate (empty means all accessible channels)
+    /// Gets or sets the list of channel IDs where the bot should operate.
     /// </summary>
+    /// <value>A list of Slack channel IDs. Empty list means the bot operates in all accessible channels.</value>
+    /// <remarks>
+    /// Use this to restrict the bot to specific channels. Channel IDs typically start with "C"
+    /// for public channels or "G" for private channels. You can find channel IDs in the Slack URL
+    /// or through the Slack API.
+    /// </remarks>
     public List<string> AllowedChannels { get; set; } = new();
 
     /// <summary>
-    /// List of user IDs that are allowed to interact with the bot (empty means all users)
+    /// Gets or sets the list of user IDs that are allowed to interact with the bot.
     /// </summary>
+    /// <value>A list of Slack user IDs. Empty list means all users can interact with the bot.</value>
+    /// <remarks>
+    /// Use this to restrict bot interactions to specific users. User IDs typically start with "U".
+    /// You can find user IDs through the Slack API or various Slack tools and apps.
+    /// </remarks>
     public List<string> AllowedUsers { get; set; } = new();
 
     /// <summary>
-    /// Whether to log incoming messages for debugging
+    /// Gets or sets a value indicating whether to log incoming messages for debugging purposes.
     /// </summary>
+    /// <value>True to log messages; otherwise, false. Defaults to false.</value>
+    /// <remarks>
+    /// When enabled, incoming messages will be logged with user and channel information.
+    /// Be cautious with this setting in production to avoid logging sensitive information.
+    /// </remarks>
     public bool LogMessages { get; set; } = false;
 
     /// <summary>
-    /// Timeout for Slack API calls in seconds
+    /// Gets or sets the timeout for Slack API calls.
     /// </summary>
+    /// <value>The timeout duration in seconds. Defaults to 30 seconds.</value>
+    /// <remarks>
+    /// This timeout applies to all HTTP requests made to the Slack API, including
+    /// sending messages and retrieving user/channel information.
+    /// </remarks>
     public int ApiTimeoutSeconds { get; set; } = 30;
 
-    // Socket Mode specific options
-
     /// <summary>
-    /// Interval for sending ping messages to keep the WebSocket connection alive (Socket Mode only)
+    /// Gets or sets the interval for sending ping messages to keep the WebSocket connection alive.
     /// </summary>
+    /// <value>The heartbeat interval. Defaults to 30 seconds.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// Ping messages help detect connection issues and prevent timeouts.
+    /// </remarks>
     public TimeSpan HeartbeatInterval { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Maximum time to wait for reconnection attempts (Socket Mode only)
+    /// Gets or sets the maximum time to wait between reconnection attempts.
     /// </summary>
+    /// <value>The reconnection timeout. Defaults to 30 seconds.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// The actual delay uses exponential backoff, capped at this maximum value.
+    /// </remarks>
     public TimeSpan ReconnectTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Maximum number of reconnection attempts before giving up (Socket Mode only)
+    /// Gets or sets the maximum number of reconnection attempts before giving up.
     /// </summary>
+    /// <value>The maximum reconnection attempts. Defaults to 10.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// After reaching this limit, the connection will be considered permanently failed.
+    /// Set to -1 for unlimited attempts.
+    /// </remarks>
     public int MaxReconnectAttempts { get; set; } = 10;
 
     /// <summary>
-    /// Whether to automatically reconnect when the WebSocket connection is lost (Socket Mode only)
+    /// Gets or sets a value indicating whether to automatically reconnect when the WebSocket connection is lost.
     /// </summary>
+    /// <value>True to enable automatic reconnection; otherwise, false. Defaults to true.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// When enabled, the client will automatically attempt to reconnect after connection failures.
+    /// </remarks>
     public bool AutoReconnect { get; set; } = true;
 
     /// <summary>
-    /// Whether to log WebSocket connection events for debugging (Socket Mode only)
+    /// Gets or sets a value indicating whether to log WebSocket connection events for debugging.
     /// </summary>
+    /// <value>True to log connection events; otherwise, false. Defaults to false.</value>
+    /// <remarks>
+    /// Only used when <see cref="Mode"/> is <see cref="SlackChannelMode.SocketMode"/>.
+    /// When enabled, connection events like connect, disconnect, and reconnection attempts
+    /// will be logged for troubleshooting purposes.
+    /// </remarks>
     public bool LogConnectionEvents { get; set; } = false;
 } 

--- a/src/Channels/Agentix.Channels.Slack/SocketModeClient.cs
+++ b/src/Channels/Agentix.Channels.Slack/SocketModeClient.cs
@@ -6,7 +6,11 @@ using System.Text.Json;
 
 namespace Agentix.Channels.Slack;
 
-public class SocketModeClient : IDisposable
+/// <summary>
+/// Internal WebSocket client for Slack Socket Mode connections.
+/// Handles WebSocket communication, reconnection logic, and message processing.
+/// </summary>
+internal class SocketModeClient : IDisposable
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<SocketModeClient> _logger;

--- a/src/Context/Agentix.Context.InMemory/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Context/Agentix.Context.InMemory/Extensions/ServiceCollectionExtensions.cs
@@ -43,27 +43,53 @@ public static class ServiceCollectionExtensions
 }
 
 /// <summary>
-/// Configuration options for in-memory context storage
+/// Configuration options for in-memory context storage.
+/// Controls cleanup behavior, memory limits, and expiration settings for conversation contexts.
 /// </summary>
-public class InMemoryContextOptions
+public sealed class InMemoryContextOptions
 {
     /// <summary>
-    /// How often to run context cleanup
+    /// Gets or sets how often to run expired context cleanup.
     /// </summary>
+    /// <value>The cleanup interval. Defaults to 5 minutes.</value>
+    /// <remarks>
+    /// The cleanup process removes expired conversations from memory to prevent memory leaks.
+    /// Shorter intervals provide more timely cleanup but use more CPU resources.
+    /// Longer intervals use less CPU but may allow expired contexts to accumulate.
+    /// </remarks>
     public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromMinutes(5);
     
     /// <summary>
-    /// Maximum number of messages to keep per context
+    /// Gets or sets the maximum number of messages to keep per conversation context.
     /// </summary>
+    /// <value>The maximum message count per context. Defaults to 100.</value>
+    /// <remarks>
+    /// When this limit is exceeded, the oldest messages are automatically removed to maintain
+    /// memory usage. This affects conversation history available to AI providers.
+    /// Higher values provide more context but use more memory.
+    /// </remarks>
     public int MaxMessagesPerContext { get; set; } = 100;
     
     /// <summary>
-    /// Maximum number of tool results to keep per context
+    /// Gets or sets the maximum number of tool results to keep per conversation context.
     /// </summary>
+    /// <value>The maximum tool result count per context. Defaults to 50.</value>
+    /// <remarks>
+    /// When this limit is exceeded, the oldest tool results are automatically removed.
+    /// Tool results provide history of function calls and their outcomes within conversations.
+    /// Higher values provide more complete tool history but use more memory.
+    /// </remarks>
     public int MaxToolResultsPerContext { get; set; } = 50;
     
     /// <summary>
-    /// Default context expiration time
+    /// Gets or sets the default expiration time for conversation contexts.
     /// </summary>
+    /// <value>The default context expiration duration. Defaults to 4 hours.</value>
+    /// <remarks>
+    /// Contexts are automatically removed after this duration of inactivity.
+    /// Individual contexts can extend their expiration, but this provides the default.
+    /// Longer expiration times allow for extended conversations but use more memory.
+    /// Shorter times free up memory faster but may interrupt long conversations.
+    /// </remarks>
     public TimeSpan DefaultExpiration { get; set; } = TimeSpan.FromHours(4);
 } 

--- a/src/Context/Agentix.Context.InMemory/InMemoryContextStore.cs
+++ b/src/Context/Agentix.Context.InMemory/InMemoryContextStore.cs
@@ -5,9 +5,15 @@ using Microsoft.Extensions.Logging;
 namespace Agentix.Context.InMemory;
 
 /// <summary>
-/// In-memory implementation of context store
+/// Internal in-memory implementation of the context store interface.
+/// Provides thread-safe context storage with automatic cleanup of expired contexts.
 /// </summary>
-public class InMemoryContextStore : IContextStore
+/// <remarks>
+/// This implementation uses concurrent collections for thread safety and includes
+/// a timer-based cleanup mechanism to remove expired contexts automatically.
+/// It's suitable for development and single-instance deployments.
+/// </remarks>
+internal class InMemoryContextStore : IContextStore
 {
     private readonly ConcurrentDictionary<string, InMemoryConversationContext> _contexts = new();
     private readonly IContextResolver _contextResolver;

--- a/src/Context/Agentix.Context.InMemory/InMemoryConversationContext.cs
+++ b/src/Context/Agentix.Context.InMemory/InMemoryConversationContext.cs
@@ -6,9 +6,15 @@ using Agentix.Core.Models;
 namespace Agentix.Context.InMemory;
 
 /// <summary>
-/// In-memory implementation of conversation context
+/// Internal in-memory implementation of conversation context interface.
+/// Provides thread-safe storage for conversation messages, key-value data, and tool results.
 /// </summary>
-public class InMemoryConversationContext : IConversationContext
+/// <remarks>
+/// This implementation uses concurrent collections to ensure thread safety and automatically
+/// manages memory by limiting the number of stored messages and tool results. It includes
+/// automatic expiration handling and data cleanup mechanisms.
+/// </remarks>
+internal class InMemoryConversationContext : IConversationContext
 {
     private readonly ConcurrentQueue<ContextMessage> _messages = new();
     private readonly ConcurrentDictionary<string, ContextData> _data = new();

--- a/src/Core/Agentix.Core/Extensions/HostExtensions.cs
+++ b/src/Core/Agentix.Core/Extensions/HostExtensions.cs
@@ -125,7 +125,21 @@ public static class HostExtensions
 /// </summary>
 public class AgentixSystemInfo
 {
+    /// <summary>
+    /// Gets or sets the list of available AI provider names in the system.
+    /// </summary>
+    /// <value>A list of provider names (e.g., "claude", "openai") that are registered and available for use.</value>
     public List<string> AvailableProviders { get; set; } = new();
+    
+    /// <summary>
+    /// Gets or sets the list of available channel adapter names in the system.
+    /// </summary>
+    /// <value>A list of channel names (e.g., "console", "slack", "teams") that are registered and available for use.</value>
     public List<string> AvailableChannels { get; set; } = new();
+    
+    /// <summary>
+    /// Gets or sets the list of channel adapter names that are currently running.
+    /// </summary>
+    /// <value>A list of channel names that are actively running and processing messages.</value>
     public List<string> RunningChannels { get; set; } = new();
 } 

--- a/src/Core/Agentix.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Agentix.Core/Extensions/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class ServiceCollectionExtensions
 /// <summary>
 /// Fluent builder for configuring Agentix services
 /// </summary>
-public class AgentixBuilder
+public sealed class AgentixBuilder
 {
     private readonly IServiceCollection _services;
 
@@ -111,7 +111,7 @@ public class AgentixBuilder
 /// <summary>
 /// Configuration options for Agentix
 /// </summary>
-public class AgentixOptions
+public sealed class AgentixOptions
 {
     /// <summary>
     /// System prompt to use for AI interactions

--- a/src/Core/Agentix.Core/Helpers/ContextHelpers.cs
+++ b/src/Core/Agentix.Core/Helpers/ContextHelpers.cs
@@ -2,7 +2,10 @@ using Agentix.Core.Models;
 
 namespace Agentix.Core.Helpers;
 
-public static class ContextHelpers
+/// <summary>
+/// Internal utility class for context-related helper methods.
+/// </summary>
+internal static class ContextHelpers
 {
     /// <summary>
     /// Generates a simple context ID for message processing.

--- a/src/Core/Agentix.Core/Interfaces/IAIProvider.cs
+++ b/src/Core/Agentix.Core/Interfaces/IAIProvider.cs
@@ -2,13 +2,53 @@ using Agentix.Core.Models;
 
 namespace Agentix.Core.Interfaces;
 
+/// <summary>
+/// Interface that all AI providers must implement to integrate with the Agentix framework.
+/// Providers are responsible for communicating with AI services and generating responses.
+/// </summary>
 public interface IAIProvider
 {
+    /// <summary>
+    /// Gets the unique name identifier of this AI provider.
+    /// </summary>
+    /// <value>A string that uniquely identifies this provider (e.g., "claude", "openai").</value>
     string Name { get; }
+    
+    /// <summary>
+    /// Gets the capabilities supported by this AI provider.
+    /// </summary>
+    /// <value>An <see cref="AICapabilities"/> object describing what features this provider supports.</value>
     AICapabilities Capabilities { get; }
     
+    /// <summary>
+    /// Generates an AI response for the given request without conversation context.
+    /// </summary>
+    /// <param name="request">The AI request containing the message and configuration.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response.</returns>
     Task<AIResponse> GenerateAsync(AIRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Generates an AI response for the given request with conversation context.
+    /// This method allows the provider to access message history and contextual data.
+    /// </summary>
+    /// <param name="request">The AI request containing the message and configuration.</param>
+    /// <param name="context">The conversation context containing message history and data.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response.</returns>
     Task<AIResponse> GenerateWithContextAsync(AIRequest request, IConversationContext context, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Estimates the cost for processing the given AI request.
+    /// </summary>
+    /// <param name="request">The AI request to estimate cost for.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the estimated cost in USD.</returns>
     Task<decimal> EstimateCostAsync(AIRequest request);
+    
+    /// <summary>
+    /// Performs a health check to verify the provider is working correctly.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is true if the provider is healthy, false otherwise.</returns>
     Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default);
 } 

--- a/src/Core/Agentix.Core/Interfaces/IChannelAdapter.cs
+++ b/src/Core/Agentix.Core/Interfaces/IChannelAdapter.cs
@@ -2,21 +2,83 @@ using Agentix.Core.Models;
 
 namespace Agentix.Core.Interfaces;
 
+/// <summary>
+/// Interface that all communication channel adapters must implement to integrate with the Agentix framework.
+/// Channels are responsible for receiving messages from users and sending responses back through specific communication platforms.
+/// </summary>
 public interface IChannelAdapter
 {
+    /// <summary>
+    /// Gets the unique name identifier of this channel adapter.
+    /// </summary>
+    /// <value>A string that uniquely identifies this channel (e.g., "console", "slack", "teams").</value>
     string Name { get; }
+    
+    /// <summary>
+    /// Gets the type of channel this adapter handles.
+    /// </summary>
+    /// <value>A string representing the channel type (e.g., "console", "slack", "teams").</value>
     string ChannelType { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether this channel is currently running and accepting messages.
+    /// </summary>
+    /// <value>True if the channel is running; otherwise, false.</value>
     bool IsRunning { get; }
     
+    /// <summary>
+    /// Starts the channel adapter and begins listening for incoming messages.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous start operation.</returns>
     Task StartAsync(CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Stops the channel adapter and ceases listening for incoming messages.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous stop operation.</returns>
     Task StopAsync(CancellationToken cancellationToken = default);
     
+    /// <summary>
+    /// Determines whether this channel adapter can handle the specified message.
+    /// </summary>
+    /// <param name="message">The incoming message to evaluate.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is true if this channel can handle the message; otherwise, false.</returns>
     Task<bool> CanHandleAsync(IncomingMessage message);
+    
+    /// <summary>
+    /// Processes an incoming message and coordinates with the AI provider to generate a response.
+    /// </summary>
+    /// <param name="message">The incoming message to process.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the channel response.</returns>
     Task<ChannelResponse> ProcessAsync(IncomingMessage message, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Sends an AI response back to the user through this channel.
+    /// </summary>
+    /// <param name="response">The AI response to send.</param>
+    /// <param name="context">The message context containing routing and metadata information.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous send operation.</returns>
     Task SendResponseAsync(AIResponse response, MessageContext context, CancellationToken cancellationToken = default);
     
-    // Channel-specific capabilities
+    /// <summary>
+    /// Gets a value indicating whether this channel supports rich content such as formatting, images, or interactive elements.
+    /// </summary>
+    /// <value>True if the channel supports rich content; otherwise, false.</value>
     bool SupportsRichContent { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether this channel supports file uploads from users.
+    /// </summary>
+    /// <value>True if the channel supports file uploads; otherwise, false.</value>
     bool SupportsFileUploads { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether this channel supports interactive elements such as buttons or menus.
+    /// </summary>
+    /// <value>True if the channel supports interactive elements; otherwise, false.</value>
     bool SupportsInteractiveElements { get; }
 } 

--- a/src/Core/Agentix.Core/Interfaces/IContextResolver.cs
+++ b/src/Core/Agentix.Core/Interfaces/IContextResolver.cs
@@ -3,12 +3,38 @@ using Agentix.Core.Models;
 namespace Agentix.Core.Interfaces;
 
 /// <summary>
-/// Resolves context boundaries and lifecycle for different channels
+/// Resolves context boundaries and lifecycle for different channels.
+/// Determines how conversation contexts are identified, managed, and configured across different communication platforms.
 /// </summary>
 public interface IContextResolver
 {
+    /// <summary>
+    /// Resolves the context identifier for a given incoming message.
+    /// This determines which conversation context the message belongs to.
+    /// </summary>
+    /// <param name="message">The incoming message to resolve context for.</param>
+    /// <returns>A unique context identifier that groups related messages together.</returns>
     string ResolveContextId(IncomingMessage message);
+    
+    /// <summary>
+    /// Gets the default expiration time for contexts in the specified channel type.
+    /// </summary>
+    /// <param name="channelType">The type of channel (e.g., "slack", "console", "teams").</param>
+    /// <returns>A <see cref="TimeSpan"/> representing how long contexts should be kept before expiring.</returns>
     TimeSpan GetDefaultExpiration(string channelType);
+    
+    /// <summary>
+    /// Gets the maximum number of messages to keep in history for the specified channel type.
+    /// </summary>
+    /// <param name="channelType">The type of channel (e.g., "slack", "console", "teams").</param>
+    /// <returns>The maximum number of messages to retain in the conversation history.</returns>
     int GetMaxMessageHistory(string channelType);
+    
+    /// <summary>
+    /// Determines whether a new conversation context should be created for the given message.
+    /// This is typically used for explicit user commands to start a new conversation.
+    /// </summary>
+    /// <param name="message">The incoming message to evaluate.</param>
+    /// <returns>True if a new context should be created, clearing any existing conversation history; otherwise, false.</returns>
     bool ShouldCreateNewContext(IncomingMessage message);
 } 

--- a/src/Core/Agentix.Core/Interfaces/IContextStore.cs
+++ b/src/Core/Agentix.Core/Interfaces/IContextStore.cs
@@ -1,14 +1,52 @@
 namespace Agentix.Core.Interfaces;
 
 /// <summary>
-/// Abstraction for storing and retrieving conversation contexts
+/// Abstraction for storing and retrieving conversation contexts.
+/// Provides persistence and management of conversation state across the application lifecycle.
 /// </summary>
 public interface IContextStore
 {
+    /// <summary>
+    /// Retrieves an existing conversation context by its identifier.
+    /// </summary>
+    /// <param name="contextId">The unique identifier of the context to retrieve.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the conversation context if found, or null if not found.</returns>
     Task<IConversationContext?> GetContextAsync(string contextId);
+    
+    /// <summary>
+    /// Creates a new conversation context with the specified parameters.
+    /// </summary>
+    /// <param name="contextId">The unique identifier for the new context.</param>
+    /// <param name="userId">The user identifier associated with this context.</param>
+    /// <param name="channelId">The channel identifier where the conversation takes place.</param>
+    /// <param name="channelType">The type of channel (e.g., "slack", "console", "teams").</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the newly created conversation context.</returns>
     Task<IConversationContext> CreateContextAsync(string contextId, string userId, string channelId, string channelType);
+    
+    /// <summary>
+    /// Saves changes made to a conversation context back to the store.
+    /// </summary>
+    /// <param name="context">The conversation context to save.</param>
+    /// <returns>A task that represents the asynchronous save operation.</returns>
     Task SaveContextAsync(IConversationContext context);
+    
+    /// <summary>
+    /// Deletes a conversation context from the store.
+    /// </summary>
+    /// <param name="contextId">The unique identifier of the context to delete.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
     Task DeleteContextAsync(string contextId);
+    
+    /// <summary>
+    /// Retrieves all context identifiers associated with a specific user.
+    /// </summary>
+    /// <param name="userId">The user identifier to find contexts for.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of context identifiers for the user.</returns>
     Task<IEnumerable<string>> GetUserContextsAsync(string userId);
+    
+    /// <summary>
+    /// Removes expired conversation contexts from the store to free up resources.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous cleanup operation.</returns>
     Task CleanupExpiredContextsAsync();
 } 

--- a/src/Core/Agentix.Core/Interfaces/IConversationContext.cs
+++ b/src/Core/Agentix.Core/Interfaces/IConversationContext.cs
@@ -3,36 +3,141 @@ using Agentix.Core.Models;
 namespace Agentix.Core.Interfaces;
 
 /// <summary>
-/// Represents a conversation context that maintains state across multiple messages
+/// Represents a conversation context that maintains state across multiple messages.
+/// Provides access to message history, key-value storage, and tool results for a specific conversation.
 /// </summary>
 public interface IConversationContext
 {
+    /// <summary>
+    /// Gets the unique identifier for this conversation context.
+    /// </summary>
+    /// <value>A string that uniquely identifies this conversation context.</value>
     string ContextId { get; }
+    
+    /// <summary>
+    /// Gets the user identifier associated with this conversation.
+    /// </summary>
+    /// <value>A string identifying the user participating in this conversation.</value>
     string UserId { get; }
+    
+    /// <summary>
+    /// Gets the channel identifier where this conversation is taking place.
+    /// </summary>
+    /// <value>A string identifying the specific channel (e.g., channel ID, chat ID).</value>
     string ChannelId { get; }
+    
+    /// <summary>
+    /// Gets the type of channel where this conversation is taking place.
+    /// </summary>
+    /// <value>A string representing the channel type (e.g., "slack", "console", "teams").</value>
     string ChannelType { get; }
+    
+    /// <summary>
+    /// Gets the date and time when this conversation context was created.
+    /// </summary>
+    /// <value>A <see cref="DateTime"/> representing when the context was created.</value>
     DateTime CreatedAt { get; }
+    
+    /// <summary>
+    /// Gets the date and time of the last activity in this conversation.
+    /// </summary>
+    /// <value>A <see cref="DateTime"/> representing the last message or interaction time.</value>
     DateTime LastActivity { get; }
+    
+    /// <summary>
+    /// Gets the date and time when this conversation context will expire.
+    /// </summary>
+    /// <value>A <see cref="DateTime"/> representing when the context expires and will be cleaned up.</value>
     DateTime ExpiresAt { get; }
     
-    // Message history management
+    /// <summary>
+    /// Retrieves the most recent messages from this conversation.
+    /// </summary>
+    /// <param name="maxCount">The maximum number of messages to retrieve. Default is 10.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of context messages ordered by timestamp.</returns>
     Task<IEnumerable<ContextMessage>> GetMessagesAsync(int maxCount = 10);
+    
+    /// <summary>
+    /// Adds a new message to this conversation's history.
+    /// </summary>
+    /// <param name="message">The context message to add to the conversation history.</param>
+    /// <returns>A task that represents the asynchronous add operation.</returns>
     Task AddMessageAsync(ContextMessage message);
+    
+    /// <summary>
+    /// Clears all messages from this conversation's history.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous clear operation.</returns>
     Task ClearMessagesAsync();
     
-    // Key-value context data storage
+    /// <summary>
+    /// Retrieves a stored value by key from the conversation's key-value storage.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to retrieve.</typeparam>
+    /// <param name="key">The key to look up in the storage.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the stored value or null if not found.</returns>
     Task<T?> GetAsync<T>(string key) where T : class;
+    
+    /// <summary>
+    /// Stores a value with the specified key in the conversation's key-value storage.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to store.</typeparam>
+    /// <param name="key">The key to store the value under.</param>
+    /// <param name="value">The value to store.</param>
+    /// <param name="expiration">Optional expiration time for this specific value.</param>
+    /// <returns>A task that represents the asynchronous set operation.</returns>
     Task SetAsync<T>(string key, T value, TimeSpan? expiration = null);
+    
+    /// <summary>
+    /// Removes a stored value by key from the conversation's key-value storage.
+    /// </summary>
+    /// <param name="key">The key of the value to remove.</param>
+    /// <returns>A task that represents the asynchronous remove operation.</returns>
     Task RemoveAsync(string key);
+    
+    /// <summary>
+    /// Retrieves all keys currently stored in the conversation's key-value storage.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of all stored keys.</returns>
     Task<IEnumerable<string>> GetKeysAsync();
     
-    // Tool results from current conversation
+    /// <summary>
+    /// Retrieves recent tool results from this conversation.
+    /// </summary>
+    /// <param name="toolName">Optional tool name to filter results. If null, returns results from all tools.</param>
+    /// <param name="maxCount">The maximum number of tool results to retrieve. Default is 5.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of tool results ordered by timestamp.</returns>
     Task<IEnumerable<ToolResult>> GetRecentToolResultsAsync(string? toolName = null, int maxCount = 5);
+    
+    /// <summary>
+    /// Adds a tool result to this conversation's history.
+    /// </summary>
+    /// <param name="result">The tool result to add to the conversation history.</param>
+    /// <returns>A task that represents the asynchronous add operation.</returns>
     Task AddToolResultAsync(ToolResult result);
     
-    // Context lifecycle
+    /// <summary>
+    /// Extends the expiration time of this conversation context.
+    /// </summary>
+    /// <param name="extension">The amount of time to extend the expiration by.</param>
+    /// <returns>A task that represents the asynchronous extend operation.</returns>
     Task ExtendExpirationAsync(TimeSpan extension);
+    
+    /// <summary>
+    /// Refreshes the last activity timestamp to the current time.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous refresh operation.</returns>
     Task RefreshActivityAsync();
+    
+    /// <summary>
+    /// Checks whether this conversation context has expired.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result is true if the context has expired; otherwise, false.</returns>
     Task<bool> IsExpiredAsync();
+    
+    /// <summary>
+    /// Clears all data from this conversation context, including messages, key-value storage, and tool results.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous clear operation.</returns>
     Task ClearAsync();
 } 

--- a/src/Core/Agentix.Core/Models/AIModels.cs
+++ b/src/Core/Agentix.Core/Models/AIModels.cs
@@ -2,160 +2,615 @@ using System.Text.Json.Nodes;
 
 namespace Agentix.Core.Models;
 
-public class IncomingMessage
+/// <summary>
+/// Represents an incoming message from a user through any communication channel.
+/// Contains all the metadata needed to process and route the message appropriately.
+/// </summary>
+public sealed class IncomingMessage
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for this message.
+    /// </summary>
+    /// <value>A unique string identifier for the message. Defaults to a new GUID.</value>
     public string Id { get; set; } = Guid.NewGuid().ToString();
+    
+    /// <summary>
+    /// Gets or sets the content of the message.
+    /// </summary>
+    /// <value>The text content of the user's message.</value>
     public string Content { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the unique identifier of the user who sent the message.
+    /// </summary>
+    /// <value>A string identifying the user across the system.</value>
     public string UserId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the display name of the user who sent the message.
+    /// </summary>
+    /// <value>The user's display name or username.</value>
     public string UserName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the identifier of the specific channel where the message was sent.
+    /// </summary>
+    /// <value>The channel-specific identifier (e.g., Slack channel ID, Teams conversation ID).</value>
     public string ChannelId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the display name of the channel where the message was sent.
+    /// </summary>
+    /// <value>The human-readable channel name.</value>
     public string ChannelName { get; set; } = string.Empty;
-    public string Channel { get; set; } = string.Empty; // "console", "slack", "teams", etc.
+    
+    /// <summary>
+    /// Gets or sets the type of channel where the message was sent.
+    /// </summary>
+    /// <value>The channel type (e.g., "console", "slack", "teams").</value>
+    public string Channel { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the timestamp when the message was received.
+    /// </summary>
+    /// <value>The UTC timestamp of when the message was received. Defaults to current UTC time.</value>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    
+    /// <summary>
+    /// Gets or sets the type of the message content.
+    /// </summary>
+    /// <value>The message type indicating the content format. Defaults to <see cref="MessageType.Text"/>.</value>
     public MessageType Type { get; set; } = MessageType.Text;
+    
+    /// <summary>
+    /// Gets or sets additional metadata associated with the message.
+    /// </summary>
+    /// <value>A dictionary containing channel-specific or custom metadata.</value>
     public Dictionary<string, object> Metadata { get; set; } = new();
 }
 
-public class AIRequest
+/// <summary>
+/// Represents a request to an AI provider for generating a response.
+/// Contains the message content, configuration, and context information needed for AI processing.
+/// </summary>
+public sealed class AIRequest
 {
+    /// <summary>
+    /// Gets or sets the content to send to the AI provider.
+    /// </summary>
+    /// <value>The text content for the AI to process and respond to.</value>
     public string Content { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the system prompt to provide context and instructions to the AI.
+    /// </summary>
+    /// <value>The system prompt that guides the AI's behavior. Defaults to <see cref="DefaultPrompts.System"/>.</value>
     public string SystemPrompt { get; set; } = DefaultPrompts.System;
+    
+    /// <summary>
+    /// Gets or sets the identifier of the user making the request.
+    /// </summary>
+    /// <value>The user identifier for tracking and personalization.</value>
     public string UserId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the identifier of the channel where the request originated.
+    /// </summary>
+    /// <value>The channel identifier for context and routing.</value>
     public string ChannelId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the conversation context identifier.
+    /// </summary>
+    /// <value>The context identifier linking this request to a conversation history.</value>
     public string ContextId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the original incoming message that triggered this AI request.
+    /// </summary>
+    /// <value>The original message with full metadata and routing information.</value>
     public IncomingMessage? OriginalMessage { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the AI-specific options and parameters for this request.
+    /// </summary>
+    /// <value>Configuration options that control AI behavior and output.</value>
     public AIRequestOptions Options { get; set; } = new();
 }
 
-public class AIResponse
+/// <summary>
+/// Represents the response from an AI provider after processing a request.
+/// Contains the generated content, metadata, usage statistics, and error information.
+/// </summary>
+public sealed class AIResponse
 {
+    /// <summary>
+    /// Gets or sets the generated content from the AI provider.
+    /// </summary>
+    /// <value>The AI-generated response content.</value>
     public string Content { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the AI request was successful.
+    /// </summary>
+    /// <value>True if the request was processed successfully; otherwise, false.</value>
     public bool Success { get; set; } = true;
+    
+    /// <summary>
+    /// Gets or sets the error message if the request failed.
+    /// </summary>
+    /// <value>A description of what went wrong, or null if the request was successful.</value>
     public string? ErrorMessage { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the type of response content.
+    /// </summary>
+    /// <value>The response type indicating the content format. Defaults to <see cref="ResponseType.Text"/>.</value>
     public ResponseType Type { get; set; } = ResponseType.Text;
     
-    // Usage and cost tracking
+    /// <summary>
+    /// Gets or sets the usage metrics for this AI request.
+    /// </summary>
+    /// <value>Token usage and other consumption metrics.</value>
     public UsageMetrics Usage { get; set; } = new();
+    
+    /// <summary>
+    /// Gets or sets the estimated cost of processing this request.
+    /// </summary>
+    /// <value>The estimated cost in USD for this AI request.</value>
     public decimal EstimatedCost { get; set; }
     
-    // Provider information
+    /// <summary>
+    /// Gets or sets the identifier of the AI provider that processed this request.
+    /// </summary>
+    /// <value>The name or identifier of the AI provider used.</value>
     public string ProviderId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the specific AI model that was used to generate the response.
+    /// </summary>
+    /// <value>The model identifier or name used by the provider.</value>
     public string ModelUsed { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the time taken to generate this response.
+    /// </summary>
+    /// <value>The duration from request start to response completion.</value>
     public TimeSpan ResponseTime { get; set; }
 }
 
-public class AIRequestOptions
+/// <summary>
+/// Configuration options for AI requests that control generation behavior.
+/// </summary>
+public sealed class AIRequestOptions
 {
+    /// <summary>
+    /// Gets or sets the creativity/randomness of the AI response.
+    /// </summary>
+    /// <value>A value between 0.0 (deterministic) and 1.0 (creative). Defaults to 0.7.</value>
     public float Temperature { get; set; } = 0.7f;
+    
+    /// <summary>
+    /// Gets or sets the maximum number of tokens to generate in the response.
+    /// </summary>
+    /// <value>The maximum output length in tokens. Defaults to 1000.</value>
     public int MaxTokens { get; set; } = 1000;
+    
+    /// <summary>
+    /// Gets or sets the specific AI model to use for this request.
+    /// </summary>
+    /// <value>The model identifier, or null to use the provider's default model.</value>
     public string? Model { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a system prompt override for this specific request.
+    /// </summary>
+    /// <value>A system prompt to use instead of the default, or null to use the default.</value>
     public string? SystemPromptOverride { get; set; }
 }
 
-public class UsageMetrics
+/// <summary>
+/// Represents token usage metrics for an AI request.
+/// Used for cost calculation and usage tracking.
+/// </summary>
+public sealed class UsageMetrics
 {
+    /// <summary>
+    /// Gets or sets the number of tokens consumed in the input (prompt and context).
+    /// </summary>
+    /// <value>The input token count.</value>
     public int InputTokens { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the number of tokens generated in the output (response).
+    /// </summary>
+    /// <value>The output token count.</value>
     public int OutputTokens { get; set; }
+    
+    /// <summary>
+    /// Gets the total number of tokens used for this request.
+    /// </summary>
+    /// <value>The sum of input and output tokens.</value>
     public int TotalTokens => InputTokens + OutputTokens;
 }
 
-public class AICapabilities
+/// <summary>
+/// Describes the capabilities and features supported by an AI provider.
+/// Used for feature detection and routing decisions.
+/// </summary>
+public sealed class AICapabilities
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether the provider supports function calling/tool use.
+    /// </summary>
+    /// <value>True if function calling is supported; otherwise, false.</value>
     public bool SupportsFunctionCalling { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the provider supports streaming responses.
+    /// </summary>
+    /// <value>True if streaming is supported; otherwise, false.</value>
     public bool SupportsStreaming { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the provider supports vision/image analysis.
+    /// </summary>
+    /// <value>True if vision capabilities are supported; otherwise, false.</value>
     public bool SupportsVision { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the maximum number of tokens the provider can generate in a single response.
+    /// </summary>
+    /// <value>The maximum output token limit for this provider.</value>
     public int MaxTokens { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the context window size (total tokens) supported by the provider.
+    /// </summary>
+    /// <value>The maximum total tokens (input + output) that can be processed.</value>
     public int ContextWindow { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the cost per input token in USD.
+    /// </summary>
+    /// <value>The cost per input token for billing calculations.</value>
     public decimal CostPerInputToken { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the cost per output token in USD.
+    /// </summary>
+    /// <value>The cost per output token for billing calculations.</value>
     public decimal CostPerOutputToken { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the models supported by this provider.
+    /// </summary>
+    /// <value>An enumerable of model identifiers or names available from this provider.</value>
     public IEnumerable<string> SupportedModels { get; set; } = new List<string>();
 }
 
-public class ChannelResponse
+/// <summary>
+/// Represents the response from a channel adapter after processing a message.
+/// Contains success status and the AI response along with channel-specific metadata.
+/// </summary>
+public sealed class ChannelResponse
 {
+    /// <summary>
+    /// Gets or sets a value indicating whether the channel successfully processed the message.
+    /// </summary>
+    /// <value>True if processing was successful; otherwise, false.</value>
     public bool Success { get; set; } = true;
+    
+    /// <summary>
+    /// Gets or sets the error message if processing failed.
+    /// </summary>
+    /// <value>A description of what went wrong, or null if processing was successful.</value>
     public string? ErrorMessage { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the AI response generated for the message.
+    /// </summary>
+    /// <value>The AI response, or null if no response was generated.</value>
     public AIResponse? AIResponse { get; set; }
+    
+    /// <summary>
+    /// Gets or sets additional metadata from the channel processing.
+    /// </summary>
+    /// <value>A dictionary containing channel-specific metadata and information.</value>
     public Dictionary<string, object> Metadata { get; set; } = new();
 }
 
-public class MessageContext
+/// <summary>
+/// Provides context information for routing and handling messages within channels.
+/// </summary>
+public sealed class MessageContext
 {
+    /// <summary>
+    /// Gets or sets the identifier of the channel where the message should be sent.
+    /// </summary>
+    /// <value>The channel identifier for routing the response.</value>
     public string ChannelId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the identifier of the user who should receive the response.
+    /// </summary>
+    /// <value>The user identifier for targeting the response.</value>
     public string UserId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the type of channel for routing decisions.
+    /// </summary>
+    /// <value>The channel type (e.g., "slack", "console", "teams").</value>
     public string Channel { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the original incoming message that triggered this context.
+    /// </summary>
+    /// <value>The original message with full metadata.</value>
     public IncomingMessage OriginalMessage { get; set; } = null!;
+    
+    /// <summary>
+    /// Gets or sets additional contextual data for message processing.
+    /// </summary>
+    /// <value>A dictionary containing additional context information.</value>
     public Dictionary<string, object> AdditionalData { get; set; } = new();
 }
 
+/// <summary>
+/// Specifies the type of content in a message.
+/// </summary>
 public enum MessageType
 {
+    /// <summary>
+    /// Plain text message content.
+    /// </summary>
     Text,
+    
+    /// <summary>
+    /// File attachment or document.
+    /// </summary>
     File,
+    
+    /// <summary>
+    /// Image content.
+    /// </summary>
     Image,
+    
+    /// <summary>
+    /// Command or action request.
+    /// </summary>
     Command
 }
 
+/// <summary>
+/// Specifies the type of content in an AI response.
+/// </summary>
 public enum ResponseType
 {
+    /// <summary>
+    /// Plain text response content.
+    /// </summary>
     Text,
+    
+    /// <summary>
+    /// Error response indicating a problem occurred.
+    /// </summary>
     Error,
+    
+    /// <summary>
+    /// Result from a tool or function call.
+    /// </summary>
     ToolResult,
+    
+    /// <summary>
+    /// Status update or informational message.
+    /// </summary>
     StatusUpdate
 }
 
-// Context system models
-
-public class ContextMessage
+/// <summary>
+/// Represents a message within a conversation context.
+/// Used for maintaining conversation history and providing context to AI providers.
+/// </summary>
+public sealed class ContextMessage
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for this context message.
+    /// </summary>
+    /// <value>A unique string identifier for the message. Defaults to a new GUID.</value>
     public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string Role { get; set; } = string.Empty; // "user", "assistant", "system", "tool"
+    
+    /// <summary>
+    /// Gets or sets the role of the message sender.
+    /// </summary>
+    /// <value>The role identifier (e.g., "user", "assistant", "system", "tool").</value>
+    public string Role { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the content of the message.
+    /// </summary>
+    /// <value>The text content of the message.</value>
     public string Content { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the timestamp when the message was created.
+    /// </summary>
+    /// <value>The UTC timestamp of message creation. Defaults to current UTC time.</value>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
-    public string? ToolName { get; set; } // If this message came from a tool
+    
+    /// <summary>
+    /// Gets or sets the name of the tool that generated this message, if applicable.
+    /// </summary>
+    /// <value>The tool name if this message came from a tool execution, or null otherwise.</value>
+    public string? ToolName { get; set; }
+    
+    /// <summary>
+    /// Gets or sets additional metadata associated with this message.
+    /// </summary>
+    /// <value>A dictionary containing message-specific metadata and context information.</value>
     public Dictionary<string, object> Metadata { get; set; } = new();
     
-    // For token counting and cost tracking
+    /// <summary>
+    /// Gets or sets the number of input tokens consumed for this message.
+    /// </summary>
+    /// <value>The input token count, or null if not tracked.</value>
     public int? InputTokens { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the number of output tokens generated for this message.
+    /// </summary>
+    /// <value>The output token count, or null if not tracked.</value>
     public int? OutputTokens { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the cost associated with this message.
+    /// </summary>
+    /// <value>The cost in USD for processing this message, or null if not tracked.</value>
     public decimal? Cost { get; set; }
 }
 
-public class ContextData
+/// <summary>
+/// Represents a key-value data entry stored in conversation context.
+/// Provides metadata and expiration information for context data management.
+/// </summary>
+public sealed class ContextData
 {
+    /// <summary>
+    /// Gets or sets the key identifier for this data entry.
+    /// </summary>
+    /// <value>The unique key within the conversation context.</value>
     public string Key { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the value stored under this key.
+    /// </summary>
+    /// <value>The data value, which can be of any type.</value>
     public object? Value { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the timestamp when this data was stored.
+    /// </summary>
+    /// <value>The UTC timestamp when the data was set. Defaults to current UTC time.</value>
     public DateTime SetAt { get; set; } = DateTime.UtcNow;
+    
+    /// <summary>
+    /// Gets or sets the expiration time for this data entry.
+    /// </summary>
+    /// <value>The UTC timestamp when this data expires, or null if it doesn't expire.</value>
     public DateTime? ExpiresAt { get; set; }
-    public string Type { get; set; } = string.Empty; // For deserialization
+    
+    /// <summary>
+    /// Gets or sets the type information for deserialization.
+    /// </summary>
+    /// <value>The type name used for proper deserialization of the value.</value>
+    public string Type { get; set; } = string.Empty;
 }
 
-public class ToolResult
+/// <summary>
+/// Represents the result of a tool execution within a conversation.
+/// Contains execution details, data, and status information for tool calls.
+/// </summary>
+public sealed class ToolResult
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for the tool call that generated this result.
+    /// </summary>
+    /// <value>The tool call identifier linking this result to the original request.</value>
     public string ToolCallId { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the name of the tool that was executed.
+    /// </summary>
+    /// <value>The tool identifier or name.</value>
     public string ToolName { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the tool execution was successful.
+    /// </summary>
+    /// <value>True if the tool executed successfully; otherwise, false.</value>
     public bool Success { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the data returned by the tool execution.
+    /// </summary>
+    /// <value>The result data from the tool, which can be of any type.</value>
     public object? Data { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a message describing the tool execution result.
+    /// </summary>
+    /// <value>A descriptive message about the execution result, or null if not provided.</value>
     public string? Message { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the error message if the tool execution failed.
+    /// </summary>
+    /// <value>A description of what went wrong, or null if execution was successful.</value>
     public string? ErrorMessage { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the time taken to execute the tool.
+    /// </summary>
+    /// <value>The duration from tool invocation to completion.</value>
     public TimeSpan ExecutionTime { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the timestamp when the tool was executed.
+    /// </summary>
+    /// <value>The UTC timestamp of tool execution. Defaults to current UTC time.</value>
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
     
-    // For long-running operations
+    /// <summary>
+    /// Gets or sets the operation identifier for long-running tool executions.
+    /// </summary>
+    /// <value>An identifier for tracking long-running operations, or null for immediate results.</value>
     public string? OperationId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the current status of the tool execution.
+    /// </summary>
+    /// <value>The execution status. Defaults to <see cref="ToolExecutionStatus.Completed"/>.</value>
     public ToolExecutionStatus Status { get; set; } = ToolExecutionStatus.Completed;
 }
 
+/// <summary>
+/// Specifies the execution status of a tool operation.
+/// </summary>
 public enum ToolExecutionStatus
 {
+    /// <summary>
+    /// The tool execution is waiting to start.
+    /// </summary>
     Pending,
+    
+    /// <summary>
+    /// The tool is currently executing.
+    /// </summary>
     Running,
+    
+    /// <summary>
+    /// The tool execution completed successfully.
+    /// </summary>
     Completed,
+    
+    /// <summary>
+    /// The tool execution failed with an error.
+    /// </summary>
     Failed,
+    
+    /// <summary>
+    /// The tool execution was cancelled before completion.
+    /// </summary>
     Cancelled
 }
 
+/// <summary>
+/// Provides default system prompts and templates for AI interactions.
+/// </summary>
 public static class DefaultPrompts
 {
+    /// <summary>
+    /// The default system prompt used when no custom prompt is specified.
+    /// </summary>
     public const string System = "You are a helpful AI assistant. Be concise and accurate in your responses.";
 } 

--- a/src/Core/Agentix.Core/Services/AgentixOrchestrator.cs
+++ b/src/Core/Agentix.Core/Services/AgentixOrchestrator.cs
@@ -10,7 +10,7 @@ namespace Agentix.Core.Services;
 /// <summary>
 /// Orchestrator that processes messages with context support using AI providers
 /// </summary>
-public class AgentixOrchestrator : IAgentixOrchestrator
+public sealed class AgentixOrchestrator : IAgentixOrchestrator
 {
     private readonly IEnumerable<IAIProvider> _providers;
     private readonly IContextStore _contextStore;
@@ -18,6 +18,14 @@ public class AgentixOrchestrator : IAgentixOrchestrator
     private readonly AgentixOptions _options;
     private readonly ILogger<AgentixOrchestrator> _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentixOrchestrator"/> class.
+    /// </summary>
+    /// <param name="providers">The collection of available AI providers.</param>
+    /// <param name="contextStore">The context store for managing conversation state.</param>
+    /// <param name="contextResolver">The context resolver for determining conversation boundaries.</param>
+    /// <param name="options">The configuration options for the orchestrator.</param>
+    /// <param name="logger">The logger for diagnostic and error information.</param>
     public AgentixOrchestrator(
         IEnumerable<IAIProvider> providers,
         IContextStore contextStore,
@@ -32,11 +40,32 @@ public class AgentixOrchestrator : IAgentixOrchestrator
         _logger = logger;
     }
 
+    /// <summary>
+    /// Processes an incoming message using the first available AI provider.
+    /// </summary>
+    /// <param name="message">The incoming message to process.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response.</returns>
+    /// <remarks>
+    /// This method uses the first available AI provider from the registered providers.
+    /// For more control over provider selection, use the overload that accepts a provider name.
+    /// </remarks>
     public async Task<AIResponse> ProcessMessageAsync(IncomingMessage message, CancellationToken cancellationToken = default)
     {
         return await ProcessMessageAsync(message, null, cancellationToken);
     }
 
+    /// <summary>
+    /// Processes an incoming message using a specific AI provider or the first available provider.
+    /// </summary>
+    /// <param name="message">The incoming message to process.</param>
+    /// <param name="providerName">The name of the specific AI provider to use, or null to use the first available provider.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response.</returns>
+    /// <remarks>
+    /// This method handles conversation context management, message history, and coordinates
+    /// between the context store and AI provider to generate contextually aware responses.
+    /// </remarks>
     public async Task<AIResponse> ProcessMessageAsync(IncomingMessage message, string? providerName = null, CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();

--- a/src/Core/Agentix.Core/Services/Context/DefaultContextResolver.cs
+++ b/src/Core/Agentix.Core/Services/Context/DefaultContextResolver.cs
@@ -5,9 +5,10 @@ using Agentix.Core.Models;
 namespace Agentix.Core.Services.Context;
 
 /// <summary>
-/// Default implementation of context resolver with channel-specific strategies
+/// Default implementation of context resolver with channel-specific strategies.
+/// This is an internal implementation that users should not depend on directly.
 /// </summary>
-public class DefaultContextResolver : IContextResolver
+internal class DefaultContextResolver : IContextResolver
 {
     public string ResolveContextId(IncomingMessage message)
     {

--- a/src/Providers/Agentix.Providers.Claude/ClaudeOptions.cs
+++ b/src/Providers/Agentix.Providers.Claude/ClaudeOptions.cs
@@ -1,14 +1,107 @@
 namespace Agentix.Providers.Claude;
 
-public class ClaudeOptions
+/// <summary>
+/// Configuration options for the Claude AI provider.
+/// Contains settings for API access, model selection, and behavior customization.
+/// </summary>
+public sealed class ClaudeOptions
 {
+    /// <summary>
+    /// Gets or sets the Anthropic API key for authenticating with Claude services.
+    /// </summary>
+    /// <value>The API key obtained from the Anthropic Console. This field is required.</value>
+    /// <remarks>
+    /// You can obtain an API key from https://console.anthropic.com/.
+    /// Keep this key secure and never commit it to source control.
+    /// </remarks>
     public string ApiKey { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the base URL for the Claude API.
+    /// </summary>
+    /// <value>The API endpoint URL. Defaults to "https://api.anthropic.com".</value>
+    /// <remarks>
+    /// Typically you won't need to change this unless you're using a proxy
+    /// or a different API environment.
+    /// </remarks>
     public string BaseUrl { get; set; } = "https://api.anthropic.com";
+    
+    /// <summary>
+    /// Gets or sets the default Claude model to use for requests.
+    /// </summary>
+    /// <value>The model identifier. Defaults to "claude-3-haiku-20240307".</value>
+    /// <remarks>
+    /// Available models include:
+    /// <list type="bullet">
+    /// <item><description>claude-3-haiku-20240307 - Fast and cost-effective</description></item>
+    /// <item><description>claude-3-sonnet-20240229 - Balanced performance and cost</description></item>
+    /// <item><description>claude-3-opus-20240229 - Highest capability and reasoning</description></item>
+    /// </list>
+    /// This can be overridden per request using <see cref="Core.Models.AIRequestOptions.Model"/>.
+    /// </remarks>
     public string DefaultModel { get; set; } = "claude-3-haiku-20240307";
+    
+    /// <summary>
+    /// Gets or sets the default temperature for response generation.
+    /// </summary>
+    /// <value>A value between 0.0 and 1.0 controlling randomness. Defaults to 0.7.</value>
+    /// <remarks>
+    /// Lower values (0.0-0.3) produce more focused and deterministic responses.
+    /// Higher values (0.7-1.0) produce more creative and varied responses.
+    /// This can be overridden per request using <see cref="Core.Models.AIRequestOptions.Temperature"/>.
+    /// </remarks>
     public float Temperature { get; set; } = 0.7f;
+    
+    /// <summary>
+    /// Gets or sets the default maximum number of tokens to generate in responses.
+    /// </summary>
+    /// <value>The maximum output tokens. Defaults to 1000.</value>
+    /// <remarks>
+    /// This controls the maximum length of Claude's responses. Higher values allow longer responses
+    /// but increase cost and latency. This can be overridden per request using 
+    /// <see cref="Core.Models.AIRequestOptions.MaxTokens"/>.
+    /// </remarks>
     public int MaxTokens { get; set; } = 1000;
+    
+    /// <summary>
+    /// Gets or sets the timeout in seconds for API requests.
+    /// </summary>
+    /// <value>The timeout duration in seconds. Defaults to 30 seconds.</value>
+    /// <remarks>
+    /// Increase this value if you're making requests that require longer processing time,
+    /// such as complex reasoning tasks or requests with large context windows.
+    /// </remarks>
     public int TimeoutSeconds { get; set; } = 30;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable automatic retry on transient failures.
+    /// </summary>
+    /// <value>True to enable retry logic; otherwise, false. Defaults to true.</value>
+    /// <remarks>
+    /// When enabled, the provider will automatically retry failed requests for transient errors
+    /// such as rate limiting or temporary network issues. The number of retries is controlled
+    /// by <see cref="MaxRetries"/>.
+    /// </remarks>
     public bool EnableRetry { get; set; } = true;
+    
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts for failed requests.
+    /// </summary>
+    /// <value>The maximum retry count. Defaults to 3.</value>
+    /// <remarks>
+    /// Only applies when <see cref="EnableRetry"/> is true. The provider uses exponential backoff
+    /// between retry attempts to avoid overwhelming the API.
+    /// </remarks>
     public int MaxRetries { get; set; } = 3;
+    
+    /// <summary>
+    /// Gets or sets the maximum number of historical messages to include in context-aware requests.
+    /// </summary>
+    /// <value>The maximum message count for conversation history. Defaults to 10.</value>
+    /// <remarks>
+    /// When using <see cref="ClaudeProvider.GenerateWithContextAsync"/>, this determines
+    /// how many previous messages from the conversation history are sent to Claude.
+    /// Higher values provide more context but increase token usage and cost.
+    /// </remarks>
     public int MaxHistoryMessages { get; set; } = 10;
 } 

--- a/src/Providers/Agentix.Providers.Claude/ClaudeProvider.cs
+++ b/src/Providers/Agentix.Providers.Claude/ClaudeProvider.cs
@@ -8,21 +8,55 @@ using Microsoft.Extensions.Logging;
 
 namespace Agentix.Providers.Claude;
 
-public class ClaudeProvider : IAIProvider
+/// <summary>
+/// Anthropic Claude AI provider implementation for the Agentix framework.
+/// Provides access to Claude's advanced language models including Haiku, Sonnet, and Opus.
+/// </summary>
+/// <remarks>
+/// This provider supports all Claude 3 models and handles cost tracking, error handling,
+/// and conversation context management. It automatically manages API communication
+/// and token usage calculation.
+/// </remarks>
+public sealed class ClaudeProvider : IAIProvider
 {
     private readonly HttpClient _httpClient;
     private readonly ClaudeOptions _options;
     private readonly ILogger<ClaudeProvider> _logger;
 
+    /// <summary>
+    /// Gets the unique name identifier for this AI provider.
+    /// </summary>
+    /// <value>Always returns "claude".</value>
     public string Name => "claude";
 
+    /// <summary>
+    /// Gets the capabilities supported by this Claude provider instance.
+    /// </summary>
+    /// <value>An <see cref="AICapabilities"/> object describing Claude's features and limitations.</value>
     public AICapabilities Capabilities { get; private set; } = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaudeProvider"/> class with default HTTP client.
+    /// </summary>
+    /// <param name="options">Configuration options for the Claude provider.</param>
+    /// <param name="logger">Logger instance for diagnostic and error information.</param>
+    /// <exception cref="ArgumentException">Thrown when the API key in options is null or empty.</exception>
     public ClaudeProvider(ClaudeOptions options, ILogger<ClaudeProvider> logger)
         : this(new HttpClient(), options, logger)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaudeProvider"/> class with a custom HTTP client.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client to use for API communications.</param>
+    /// <param name="options">Configuration options for the Claude provider.</param>
+    /// <param name="logger">Logger instance for diagnostic and error information.</param>
+    /// <exception cref="ArgumentException">Thrown when the API key in options is null or empty.</exception>
+    /// <remarks>
+    /// Using a custom HTTP client allows for advanced scenarios like connection pooling,
+    /// custom timeout configurations, or HTTP message handlers for testing.
+    /// </remarks>
     public ClaudeProvider(HttpClient httpClient, ClaudeOptions options, ILogger<ClaudeProvider> logger)
     {
         _httpClient = httpClient;
@@ -41,6 +75,16 @@ public class ClaudeProvider : IAIProvider
         _logger.LogInformation("Claude provider initialized with model {Model}", _options.DefaultModel);
     }
 
+    /// <summary>
+    /// Generates an AI response for the given request without conversation context.
+    /// </summary>
+    /// <param name="request">The AI request containing the message and configuration.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response from Claude.</returns>
+    /// <remarks>
+    /// This method sends a single message to Claude without any conversation history.
+    /// For conversations that require context, use <see cref="GenerateWithContextAsync"/> instead.
+    /// </remarks>
     public async Task<AIResponse> GenerateAsync(AIRequest request, CancellationToken cancellationToken = default)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -82,6 +126,18 @@ public class ClaudeProvider : IAIProvider
         }
     }
 
+    /// <summary>
+    /// Generates an AI response for the given request with conversation context.
+    /// </summary>
+    /// <param name="request">The AI request containing the message and configuration.</param>
+    /// <param name="context">The conversation context containing message history and data.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the AI response from Claude.</returns>
+    /// <remarks>
+    /// This method includes conversation history from the context when generating the response,
+    /// allowing Claude to maintain coherent conversations and refer to previous messages.
+    /// The number of historical messages included is controlled by <see cref="ClaudeOptions.MaxHistoryMessages"/>.
+    /// </remarks>
     public async Task<AIResponse> GenerateWithContextAsync(AIRequest request, IConversationContext context, CancellationToken cancellationToken = default)
     {
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -123,6 +179,16 @@ public class ClaudeProvider : IAIProvider
         }
     }
 
+    /// <summary>
+    /// Estimates the cost for processing the given AI request.
+    /// </summary>
+    /// <param name="request">The AI request to estimate cost for.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the estimated cost in USD.</returns>
+    /// <remarks>
+    /// This method provides a rough cost estimation based on character count approximation.
+    /// Actual costs may vary slightly due to differences in tokenization. The estimation
+    /// uses the current model's pricing as configured in <see cref="Capabilities"/>.
+    /// </remarks>
     public Task<decimal> EstimateCostAsync(AIRequest request)
     {
         // Rough estimation based on character count
@@ -136,6 +202,15 @@ public class ClaudeProvider : IAIProvider
         return Task.FromResult(cost);
     }
 
+    /// <summary>
+    /// Performs a health check to verify the Claude provider is working correctly.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result is true if the provider is healthy, false otherwise.</returns>
+    /// <remarks>
+    /// The health check sends a simple "Hello" message to Claude with minimal token usage
+    /// to verify API connectivity, authentication, and basic functionality.
+    /// </remarks>
     public async Task<bool> HealthCheckAsync(CancellationToken cancellationToken = default)
     {
         try
@@ -364,6 +439,13 @@ public class ClaudeProvider : IAIProvider
         };
     }
 
+    /// <summary>
+    /// Releases all resources used by the <see cref="ClaudeProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method disposes the internal HTTP client if it was created by this provider.
+    /// If a custom HTTP client was provided in the constructor, it will also be disposed.
+    /// </remarks>
     public void Dispose()
     {
         _httpClient?.Dispose();

--- a/src/Providers/Agentix.Providers.Claude/Models/ClaudeApiModels.cs
+++ b/src/Providers/Agentix.Providers.Claude/Models/ClaudeApiModels.cs
@@ -2,7 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace Agentix.Providers.Claude.Models;
 
-public class ClaudeRequest
+/// <summary>
+/// Internal model representing a request to the Claude API.
+/// </summary>
+internal class ClaudeRequest
 {
     [JsonPropertyName("model")]
     public string Model { get; set; } = string.Empty;
@@ -21,7 +24,10 @@ public class ClaudeRequest
     public string? System { get; set; }
 }
 
-public class ClaudeMessage
+/// <summary>
+/// Internal model representing a message in a Claude API request.
+/// </summary>
+internal class ClaudeMessage
 {
     [JsonPropertyName("role")]
     public string Role { get; set; } = string.Empty;
@@ -30,7 +36,10 @@ public class ClaudeMessage
     public string Content { get; set; } = string.Empty;
 }
 
-public class ClaudeResponse
+/// <summary>
+/// Internal model representing a response from the Claude API.
+/// </summary>
+internal class ClaudeResponse
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
@@ -57,7 +66,10 @@ public class ClaudeResponse
     public ClaudeUsage Usage { get; set; } = new();
 }
 
-public class ClaudeContent
+/// <summary>
+/// Internal model representing content in a Claude API response.
+/// </summary>
+internal class ClaudeContent
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
@@ -66,7 +78,10 @@ public class ClaudeContent
     public string Text { get; set; } = string.Empty;
 }
 
-public class ClaudeUsage
+/// <summary>
+/// Internal model representing token usage in a Claude API response.
+/// </summary>
+internal class ClaudeUsage
 {
     [JsonPropertyName("input_tokens")]
     public int InputTokens { get; set; }
@@ -75,7 +90,10 @@ public class ClaudeUsage
     public int OutputTokens { get; set; }
 }
 
-public class ClaudeError
+/// <summary>
+/// Internal model representing an error response from the Claude API.
+/// </summary>
+internal class ClaudeError
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
@@ -84,7 +102,10 @@ public class ClaudeError
     public ClaudeErrorDetail Error { get; set; } = new();
 }
 
-public class ClaudeErrorDetail
+/// <summary>
+/// Internal model representing error details in a Claude API error response.
+/// </summary>
+internal class ClaudeErrorDetail
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;


### PR DESCRIPTION
- Add complete XML documentation to all public interfaces, classes, and members
- Make internal implementation classes `internal` to hide implementation details:
  * Claude API models (ClaudeRequest, ClaudeResponse, etc.)
  * Slack API models (SlackEventCallback, SlackMessage, etc.)
  * Internal services (DefaultContextResolver, ContextHelpers)
  * Context implementations (InMemoryContextStore, InMemoryConversationContext)
  * Socket mode client (SocketModeClient)
- Seal concrete classes to prevent unwanted inheritance:
  * Provider implementations (ClaudeProvider)
  * Channel implementations (ConsoleChannelAdapter, SlackChannelAdapter)
  * Core services (AgentixOrchestrator)
  * Configuration classes (all *Options classes, AgentixBuilder)
  * Model/DTO classes (IncomingMessage, AIRequest, AIResponse, etc.)

These changes establish a clean API boundary where only interfaces and essential public classes are exposed to package consumers, while providing rich IntelliSense documentation for all public members. Implementation details are now properly encapsulated as internal.

Fixes XML documentation warnings and improves overall API design for NuGet package publishing.