### PR TITLE
fix: make context services optional to support stateless operation

### DIFF
--- a/src/Context/Agentix.Context.InMemory/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Context/Agentix.Context.InMemory/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(options);
         services.AddSingleton<IContextStore, InMemoryContextStore>();
         
+        // Also register the default context resolver since both are needed together
+        services.AddContextResolver();
+        
         return services;
     }
 

--- a/src/Core/Agentix.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Agentix.Core/Extensions/ServiceCollectionExtensions.cs
@@ -24,8 +24,8 @@ public static class ServiceCollectionExtensions
         // Register core services
         services.AddSingleton<IAgentixOrchestrator, AgentixOrchestrator>();
         
-        // Add default context resolver
-        services.AddContextResolver();
+        // Note: Context services (IContextStore, IContextResolver) are now opt-in
+        // Add them explicitly via .AddInMemoryContext() or similar extensions
         
         // Add logging if not already configured
         services.AddLogging(builder =>
@@ -87,8 +87,12 @@ public sealed class AgentixBuilder
     }
 
     /// <summary>
-    /// Configure a custom context resolver
+    /// Configure a custom context resolver (requires context store to also be registered)
     /// </summary>
+    /// <remarks>
+    /// This method is typically used with context-enabled configurations.
+    /// Ensure you have also registered an IContextStore implementation via .AddInMemoryContext() or similar.
+    /// </remarks>
     public AgentixBuilder WithContextResolver<T>() where T : class, IContextResolver
     {
         // Remove existing context resolver registration

--- a/src/Core/Agentix.Core/Services/AgentixOrchestrator.cs
+++ b/src/Core/Agentix.Core/Services/AgentixOrchestrator.cs
@@ -8,13 +8,13 @@ using Microsoft.Extensions.Logging;
 namespace Agentix.Core.Services;
 
 /// <summary>
-/// Orchestrator that processes messages with context support using AI providers
+/// Orchestrator that processes messages with optional context support using AI providers
 /// </summary>
 public sealed class AgentixOrchestrator : IAgentixOrchestrator
 {
     private readonly IEnumerable<IAIProvider> _providers;
-    private readonly IContextStore _contextStore;
-    private readonly IContextResolver _contextResolver;
+    private readonly IContextStore? _contextStore;
+    private readonly IContextResolver? _contextResolver;
     private readonly AgentixOptions _options;
     private readonly ILogger<AgentixOrchestrator> _logger;
 
@@ -22,17 +22,26 @@ public sealed class AgentixOrchestrator : IAgentixOrchestrator
     /// Initializes a new instance of the <see cref="AgentixOrchestrator"/> class.
     /// </summary>
     /// <param name="providers">The collection of available AI providers.</param>
-    /// <param name="contextStore">The context store for managing conversation state.</param>
-    /// <param name="contextResolver">The context resolver for determining conversation boundaries.</param>
     /// <param name="options">The configuration options for the orchestrator.</param>
     /// <param name="logger">The logger for diagnostic and error information.</param>
+    /// <param name="contextStore">Optional context store for managing conversation state. If provided, contextResolver must also be provided.</param>
+    /// <param name="contextResolver">Optional context resolver for determining conversation boundaries. If provided, contextStore must also be provided.</param>
+    /// <exception cref="InvalidOperationException">Thrown when only one of contextStore or contextResolver is provided.</exception>
     public AgentixOrchestrator(
         IEnumerable<IAIProvider> providers,
-        IContextStore contextStore,
-        IContextResolver contextResolver,
         AgentixOptions options,
-        ILogger<AgentixOrchestrator> logger)
+        ILogger<AgentixOrchestrator> logger,
+        IContextStore? contextStore = null,
+        IContextResolver? contextResolver = null)
     {
+        // Validation: both context services must be present together or both null
+        if ((contextStore == null) != (contextResolver == null))
+        {
+            throw new InvalidOperationException(
+                "IContextStore and IContextResolver must both be provided or both be null. " +
+                "For stateless operation, omit both. For stateful operation, provide both via .AddInMemoryContext() or similar.");
+        }
+
         _providers = providers;
         _contextStore = contextStore;
         _contextResolver = contextResolver;
@@ -63,8 +72,9 @@ public sealed class AgentixOrchestrator : IAgentixOrchestrator
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the AI response.</returns>
     /// <remarks>
-    /// This method handles conversation context management, message history, and coordinates
-    /// between the context store and AI provider to generate contextually aware responses.
+    /// This method handles conversation context management (if context services are available), message history, 
+    /// and coordinates between the context store and AI provider to generate contextually aware responses.
+    /// In stateless mode (no context services), processes messages without conversation history.
     /// </remarks>
     public async Task<AIResponse> ProcessMessageAsync(IncomingMessage message, string? providerName = null, CancellationToken cancellationToken = default)
     {
@@ -95,86 +105,15 @@ public sealed class AgentixOrchestrator : IAgentixOrchestrator
                 };
             }
 
-            // Resolve context for this message
-            var contextId = _contextResolver.ResolveContextId(message);
-            
-            // Check if we should create a new context
-            if (_contextResolver.ShouldCreateNewContext(message))
+            // Process with or without context based on availability
+            if (_contextStore != null && _contextResolver != null)
             {
-                await _contextStore.DeleteContextAsync(contextId);
-                _logger.LogInformation("Creating new context for user request: {ContextId}", contextId);
-            }
-            
-            // Get or create context
-            var context = await _contextStore.GetContextAsync(contextId) 
-                         ?? await _contextStore.CreateContextAsync(contextId, message.UserId, message.ChannelId, message.Channel);
-
-            // Add user message to context
-            await context.AddMessageAsync(new ContextMessage
-            {
-                Role = "user",
-                Content = message.Content,
-                Metadata = { 
-                    ["channel"] = message.Channel,
-                    ["channelId"] = message.ChannelId,
-                    ["userName"] = message.UserName
-                }
-            });
-
-            // Build AI request
-            var aiRequest = new AIRequest
-            {
-                Content = message.Content,
-                SystemPrompt = _options.SystemPrompt,
-                UserId = message.UserId,
-                ChannelId = message.ChannelId,
-                ContextId = contextId,
-                OriginalMessage = message
-            };
-
-            _logger.LogInformation("Processing message from {UserId} in {Channel} using provider {Provider} (Context: {ContextId})", 
-                                 message.UserId, message.Channel, provider.Name, contextId);
-
-            // Generate response with context
-            AIResponse response;
-            if (provider.GetType().GetMethod("GenerateWithContextAsync") != null)
-            {
-                // Provider supports context
-                response = await provider.GenerateWithContextAsync(aiRequest, context, cancellationToken);
+                return await ProcessWithContextAsync(message, provider, stopwatch, cancellationToken);
             }
             else
             {
-                // Fallback to non-context method
-                response = await provider.GenerateAsync(aiRequest, cancellationToken);
+                return await ProcessStatelessAsync(message, provider, stopwatch, cancellationToken);
             }
-            
-            response.ResponseTime = stopwatch.Elapsed;
-
-            // Save assistant response to context
-            if (response.Success)
-            {
-                await context.AddMessageAsync(new ContextMessage
-                {
-                    Role = "assistant",
-                    Content = response.Content,
-                    InputTokens = response.Usage.InputTokens,
-                    OutputTokens = response.Usage.OutputTokens,
-                    Cost = response.EstimatedCost,
-                    Metadata = { 
-                        ["model"] = response.ModelUsed,
-                        ["provider"] = response.ProviderId
-                    }
-                });
-            }
-
-            // Save context changes
-            await _contextStore.SaveContextAsync(context);
-
-            _logger.LogInformation("Generated response in {Duration}ms using {Provider} (Tokens: {InputTokens}/{OutputTokens}, Cost: ${Cost:F4})", 
-                                 stopwatch.ElapsedMilliseconds, provider.Name, 
-                                 response.Usage.InputTokens, response.Usage.OutputTokens, response.EstimatedCost);
-
-            return response;
         }
         catch (Exception ex)
         {
@@ -188,5 +127,122 @@ public sealed class AgentixOrchestrator : IAgentixOrchestrator
                 ResponseTime = stopwatch.Elapsed
             };
         }
+    }
+
+    /// <summary>
+    /// Processes a message with context support (stateful mode)
+    /// </summary>
+    private async Task<AIResponse> ProcessWithContextAsync(IncomingMessage message, IAIProvider provider, Stopwatch stopwatch, CancellationToken cancellationToken)
+    {
+        // Resolve context for this message
+        var contextId = _contextResolver!.ResolveContextId(message);
+        
+        // Check if we should create a new context
+        if (_contextResolver.ShouldCreateNewContext(message))
+        {
+            await _contextStore!.DeleteContextAsync(contextId);
+            _logger.LogInformation("Creating new context for user request: {ContextId}", contextId);
+        }
+        
+        // Get or create context
+        var context = await _contextStore!.GetContextAsync(contextId) 
+                     ?? await _contextStore.CreateContextAsync(contextId, message.UserId, message.ChannelId, message.Channel);
+
+        // Add user message to context
+        await context.AddMessageAsync(new ContextMessage
+        {
+            Role = "user",
+            Content = message.Content,
+            Metadata = { 
+                ["channel"] = message.Channel,
+                ["channelId"] = message.ChannelId,
+                ["userName"] = message.UserName
+            }
+        });
+
+        // Build AI request
+        var aiRequest = new AIRequest
+        {
+            Content = message.Content,
+            SystemPrompt = _options.SystemPrompt,
+            UserId = message.UserId,
+            ChannelId = message.ChannelId,
+            ContextId = contextId,
+            OriginalMessage = message
+        };
+
+        _logger.LogInformation("Processing message from {UserId} in {Channel} using provider {Provider} (Context: {ContextId})", 
+                             message.UserId, message.Channel, provider.Name, contextId);
+
+        // Generate response with context
+        AIResponse response;
+        if (provider.GetType().GetMethod("GenerateWithContextAsync") != null)
+        {
+            // Provider supports context
+            response = await provider.GenerateWithContextAsync(aiRequest, context, cancellationToken);
+        }
+        else
+        {
+            // Fallback to non-context method
+            response = await provider.GenerateAsync(aiRequest, cancellationToken);
+        }
+        
+        response.ResponseTime = stopwatch.Elapsed;
+
+        // Save assistant response to context
+        if (response.Success)
+        {
+            await context.AddMessageAsync(new ContextMessage
+            {
+                Role = "assistant",
+                Content = response.Content,
+                InputTokens = response.Usage.InputTokens,
+                OutputTokens = response.Usage.OutputTokens,
+                Cost = response.EstimatedCost,
+                Metadata = { 
+                    ["model"] = response.ModelUsed,
+                    ["provider"] = response.ProviderId
+                }
+            });
+        }
+
+        // Save context changes
+        await _contextStore.SaveContextAsync(context);
+
+        _logger.LogInformation("Generated response in {Duration}ms using {Provider} (Tokens: {InputTokens}/{OutputTokens}, Cost: ${Cost:F4})", 
+                             stopwatch.ElapsedMilliseconds, provider.Name, 
+                             response.Usage.InputTokens, response.Usage.OutputTokens, response.EstimatedCost);
+
+        return response;
+    }
+
+    /// <summary>
+    /// Processes a message without context support (stateless mode)
+    /// </summary>
+    private async Task<AIResponse> ProcessStatelessAsync(IncomingMessage message, IAIProvider provider, Stopwatch stopwatch, CancellationToken cancellationToken)
+    {
+        // Build AI request without context
+        var aiRequest = new AIRequest
+        {
+            Content = message.Content,
+            SystemPrompt = _options.SystemPrompt,
+            UserId = message.UserId,
+            ChannelId = message.ChannelId,
+            ContextId = string.Empty, // No context in stateless mode
+            OriginalMessage = message
+        };
+
+        _logger.LogInformation("Processing message from {UserId} in {Channel} using provider {Provider} (Stateless mode)", 
+                             message.UserId, message.Channel, provider.Name);
+
+        // Generate response without context
+        var response = await provider.GenerateAsync(aiRequest, cancellationToken);
+        response.ResponseTime = stopwatch.Elapsed;
+
+        _logger.LogInformation("Generated response in {Duration}ms using {Provider} (Tokens: {InputTokens}/{OutputTokens}, Cost: ${Cost:F4}) [Stateless]", 
+                             stopwatch.ElapsedMilliseconds, provider.Name, 
+                             response.Usage.InputTokens, response.Usage.OutputTokens, response.EstimatedCost);
+
+        return response;
     }
 } 


### PR DESCRIPTION
Remove required dependency on IContextStore/IContextResolver from AgentixOrchestrator to fix DI resolution errors in simple scenarios. Framework now works with or without .AddInMemoryContext().